### PR TITLE
change from p3 get genome groups command to api command

### DIFF
--- a/lib/CoreGenomeMLST.pm
+++ b/lib/CoreGenomeMLST.pm
@@ -98,47 +98,31 @@ sub run
     if ($params->{input_genome_type} eq 'genome_group')
     {
         my $genome_group_path = $params->{input_genome_group};
+        print($genome_group_path);
         my $group_name = basename($genome_group_path);
-
-        # Get all patric ids via p3-get-genome-group
-        my @cmd = ("p3-get-genome-group", $group_name);
-        my $genome_list;
-        my $ok = IPC::Run::run(\@cmd, '>', \$genome_list);
-
-        if (!$ok) {
-            die "p3-get-genome-group execution failed: @cmd\n";
-            }
-
-        # Loop through each genome ID and fetch the fasta
-        my @genome_ids = split(/\n/, $genome_list);
-        shift @genome_ids;  # Removes the genome name
-        foreach my $genome_id (@genome_ids){
-            chomp $genome_id;
-            # next unless $genome_id; # skip empty lines
-            my $fasta_file = "$raw_fasta_dir/$genome_id.fasta";
-
-            # Run p3-genome-fasta for each genome ID
-            my @fasta_cmd = ("p3-genome-fasta", "--contig", $genome_id);
-            my $fasta_output;
-
-            my $stderr;
-            my $ok = IPC::Run::run(\@fasta_cmd, '>', \$fasta_output, '2>', \$stderr);
-            if (!$ok || $stderr) {
-                die "p3-genome-fasta execution failed for $genome_id: @fasta_cmd\nError: $stderr\n";
-            }
-
-            # Write FASTA output to file
-            open(my $fh, '>', $fasta_file) or die "Could not open $fasta_file: $!\n";
-
-            if ($fasta_output) {
-                print $fh $fasta_output;
-            } else {
-                warn "Warning: No FASTA data retrieved for genome ID $genome_id\n";
-            }
-            close($fh);
-
-            print "Saved FASTA for $genome_id to $fasta_file\n";
-        }
+        my $api = P3DataAPI->new;
+        my @group_genome_ids = $api->retrieve_patric_ids_from_genome_group($genome_group_path);
+        $api ->retrieve_contigs_in_genomes(@group_genome_ids, $raw_fasta_dir, "%s");
+        # # my @genome_metadata_fields = (
+        # #   "genome_name", "genome_id", "ncbi_taxon_id", "organism_name", "taxon_lineage_ids", "taxon_lineage_names",
+        # #   "superkingdom", "kingdom", "phylum", "class", "order", "family", "genus", "species", "genome_status", "strain", 
+        # #   "serovar", "isolation_source", "isolation_comments", "collection_date", "collection_year", "season", 
+        # #   "isolation_country", "geographic_group", "geographic_country", "geographic_location", "host_name", "host_common_name",
+        # #   "host_gender", "host_age", "lab_host", "passage", "sequencing_center", "sequencing_status", "sequencing_platform", "chromosomes", 
+        # #   "plasmids", "contigs", "genome_length", "gc_content", "contig_l50", "contig_n50", "cds", "genome_quality", 
+        # #   "antimicrobial_resistance", "antimicrobial_resistance_evidence", "bioproject_accession", "biosample_accession", "assembly_accession",
+        # #   "sra_accession", "genbank_accession", "refseq_accession", "comments", "date_inserted", "date_modified", "public", "owner", "members", "",
+        # #   "accession", "patric_id", "public", "genome_status", "state");
+        my @genome_metadata_fields = (
+        "genome_id", "genome_name", "species", "strain", "genbank_accessions", "subtype", "lineage", "clade", "host_group", 
+        "host_common_name", "host_scientific_name", "collection_year", "geographic_group", "isolation_country", "genome_status", 
+        "state_province", "state");
+        my @genome_group_metadata = $api->retrieve_genome_metadata(@group_genome_ids, \@genome_metadata_fields);
+        my $json_string = encode_json(@genome_group_metadata);
+        print $json_string;
+        # write metdata to json
+        my $top = getcwd;
+        write_file("$top/genome_metadata.json", JSON::XS->new->pretty->canonical->encode(\@genome_group_metadata));
     }
 
     # Prep the config and get ready to run Snakemake

--- a/service-scripts/core-genome-mlst-utils.py
+++ b/service-scripts/core-genome-mlst-utils.py
@@ -7,13 +7,22 @@ import re
 import shutil
 
 # Ensure files adhere to the rules defined in the the chewbbaca allele call function
-
 def chewbbaca_filename_format(filename):
     # Rule 1 Replace spaces and illegal characters with underscores
     name, ext = os.path.splitext(filename)
-    new_filename = re.sub(r'[^A-Za-z0-9_\-]', '_', name)
-    new_filename = "{}{}".format(new_filename, ext)
-    return new_filename
+    if ext != ".fasta":
+        # add_extension = os.path.join(filename, ".fasta")
+        add_extension = filename + ".fasta"
+        name, ext = os.path.splitext(add_extension)
+    
+    # Rule 1: Remove extra dots in the name (keep only one before the extension)
+    name = name.replace(".", "_")
+
+    # Rule 2: Replace spaces and illegal characters with underscores
+    name = re.sub(r'[^A-Za-z0-9_\-]', '_', name)
+
+    # Ensure we return a properly formatted filename
+    return "{}{}".format(name, ext)
 
 def copy_new_file(clean_fasta_dir, new_name, filename, original_path):
     # deal with moving the files 


### PR DESCRIPTION
Hey Bob, 
When I updated Whole Genome SNP to use the api for genome groups. I forgot to make the same update 
This change was made because p3-get-genomes was not working for genome groups in shared workspaces.
This has been tested and shouldn't impact the service (given that the same approach is used in wgSNP).
Kind regards,
Nicole 